### PR TITLE
Option for having Markdown files concatenated to the begining/end of the generated documentation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,12 +7,21 @@ module.exports = function(grunt) {
                 src: "test/fixture/*.js",
                 dest: "test/output/docs.md"
             },
+            oneOutputFileWithExtraMarkdown: {
+                src: "test/fixture/*.js",
+                dest: "test/output/docsWithExtraMarkdown.md",
+                options: {
+                    "introMd": "test/begin.md",
+                    "endMd": "test/end.md"
+                }
+            },
             separateOutputFiles: {
                 files: [
                     { src: "test/fixture/class.js", dest: "test/output/class.md" },
                     { src: "test/fixture/typedef.js", dest: "test/output/typedef.md" }
                 ]
             },
+
             withOptions: {
                 options: {
                     "no-gfm": true

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "tape": "^4"
   },
   "dependencies": {
+    "concat-files": "^0.1.0",
     "jsdoc-to-markdown": "^1",
     "more-fs": "~0.5.0"
   }

--- a/tasks/jsdoc2md.js
+++ b/tasks/jsdoc2md.js
@@ -1,6 +1,7 @@
 "use strict";
 var jsdoc2md = require("jsdoc-to-markdown");
 var mfs = require("more-fs");
+var concat = require("concat-files");
 
 module.exports = function(grunt) {
     grunt.registerMultiTask("jsdoc2md", "API documentation generator", function() {
@@ -10,10 +11,31 @@ module.exports = function(grunt) {
         var monitor = {
             finished: 0,
             done: function(){
-                this.finished++;
-                if (this.finished === self.files.length) done();
+                monitor.finished++;
+                if (monitor.finished === self.files.length) done();
             }
         };
+
+        function concatMD(concatOptions, cb) {
+            var files = [];
+            if (concatOptions.intro) {
+                files.push(concatOptions.intro); 
+            }
+
+            files.push(concatOptions.outputPath);
+
+            if (concatOptions.end) {
+                files.push(concatOptions.end); 
+            }
+
+            mfs.mkdir('.concat-tmp');
+            concat(files, '.concat-tmp/temp.md', function() {
+                mfs.duplicate('.concat-tmp/temp.md', concatOptions.outputPath);
+                mfs.deleteFile('.concat-tmp/temp.md');
+                mfs.rmdir('.concat-tmp');
+                cb();
+            });
+        }
 
         this.files.forEach(function(file){
             var outputPath = file.dest;
@@ -22,7 +44,17 @@ module.exports = function(grunt) {
             grunt.log.oklns("writing " + outputPath);
             renderStream.on("error", grunt.fail.fatal);
             renderStream.on("end", function(){
-                monitor.done();
+                console.log(options);
+                if (options.introMd || options.endMd) {
+                    var concatOptions = {
+                        intro: options.introMd,
+                        outputPath: outputPath,
+                        end: options.endMd
+                    };
+                    concatMD(concatOptions, monitor.done); 
+                } else {
+                    monitor.done(); 
+                }    
             });
 
             /* dest directories will be created if they don't exist  */

--- a/test/begin.md
+++ b/test/begin.md
@@ -1,0 +1,4 @@
+# INTRO MARKDOWN
+
+Lorem ipsum dolor sit amet, est nonumy nonumes in. Natum tacimates nam no, in noluisse neglegentur nec, bonorum erroribus eu duo. An pro inermis facilisis torquatos, an elit oratio expetendis sea, mei id propriae eligendi. Eos partem integre id. Sit ne tractatos quaerendum comprehensam.
+

--- a/test/end.md
+++ b/test/end.md
@@ -1,0 +1,4 @@
+## END MARKDOWN
+
+An nec aliquid ocurreret, eos everti feugiat in, congue posidonium vis no. Ne cum doming probatus, mel choro iudico ubique in, sed ei odio errem. Eu dico stet splendide sea, exerci adolescens sed ne, cum epicuri conceptam et. Sea veri minim mandamus ne, aeterno offendit elaboraret eum te.
+

--- a/test/output/docsWithExtraMarkdown.md
+++ b/test/output/docsWithExtraMarkdown.md
@@ -1,0 +1,142 @@
+# INTRO MARKDOWN
+
+Lorem ipsum dolor sit amet, est nonumy nonumes in. Natum tacimates nam no, in noluisse neglegentur nec, bonorum erroribus eu duo. An pro inermis facilisis torquatos, an elit oratio expetendis sea, mei id propriae eligendi. Eos partem integre id. Sit ne tractatos quaerendum comprehensam.
+
+## Modules
+<dl>
+<dt><a href="#module_object">object</a></dt>
+<dd><p>simple object export</p>
+</dd>
+</dl>
+## Classes
+<dl>
+<dt><del><a href="#All">All</a> ⇐ <code>Number</code></del></dt>
+<dd><p>a class with all of the things</p>
+</dd>
+</dl>
+## Functions
+<dl>
+<dt><a href="#setMagicNumber">setMagicNumber(x)</a></dt>
+<dd><p>Set the magic number.</p>
+</dd>
+</dl>
+## Typedefs
+<dl>
+<dt><a href="#NumberLike">NumberLike</a> : <code>number</code> | <code>string</code></dt>
+<dd><p>A number, or a string containing a number.</p>
+</dd>
+</dl>
+<a name="module_object"></a>
+## object
+simple object export
+
+
+* [object](#module_object)
+  * [.one](#module_object.one)
+  * [.three(four, five)](#module_object.three) ⇒ <code>object</code> &#124; <code>string</code>
+
+<a name="module_object.one"></a>
+### object.one
+first property
+
+**Kind**: static property of <code>[object](#module_object)</code>  
+<a name="module_object.three"></a>
+### object.three(four, five) ⇒ <code>object</code> &#124; <code>string</code>
+a function
+
+**Kind**: static method of <code>[object](#module_object)</code>  
+**Returns**: <code>object</code> &#124; <code>string</code> - this return has several types  
+**Since**: v0.10.28  
+**Author:** Lloyd <75pound@gmail.com>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| four | <code>string</code> | The input string |
+| five | <code>object</code> | a second input |
+
+**Example**  
+```js
+allTogether(true);
+```
+<a name="All"></a>
+## ~~All ⇐ <code>Number</code>~~
+***Deprecated***
+
+a class with all of the things
+
+**Kind**: global class  
+**Extends:** <code>Number</code>  
+**Since**: v0.10.28  
+**Author:** 75lb <75pound@gmail.com>  
+
+* ~~[All](#All) ⇐ <code>Number</code>~~
+  * [new All(input, [options])](#new_All_new)
+  * [.topping](#All#topping) : <code>string</code>
+  * [.size](#All#size)
+  * ~~[.allThings(one, two)](#All#allThings) ⇒ <code>object</code> &#124; <code>string</code>~~
+
+<a name="new_All_new"></a>
+### new All(input, [options])
+the constructor description
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| input | <code>object</code> | an input |
+| [options] | <code>object</code> | optional shit |
+
+**Example**  
+```js
+var yeah = new Everything(true);
+```
+<a name="All#topping"></a>
+### all.topping : <code>string</code>
+the ingredients on top
+
+**Kind**: instance property of <code>[All](#All)</code>  
+**Default**: <code>&quot;mud, lettuce&quot;</code>  
+**Since**: v1.0.0  
+<a name="All#size"></a>
+### all.size
+the general size
+
+**Kind**: instance property of <code>[All](#All)</code>  
+<a name="All#allThings"></a>
+### ~~all.allThings(one, two) ⇒ <code>object</code> &#124; <code>string</code>~~
+***Deprecated***
+
+This function has all tags set
+
+**Kind**: instance method of <code>[All](#All)</code>  
+**Returns**: <code>object</code> &#124; <code>string</code> - this return has several types  
+**Since**: v0.10.28  
+**Author:** Lloyd <75pound@gmail.com>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| one | <code>string</code> | The input string |
+| two | <code>object</code> | a second input |
+
+**Example**  
+```js
+all.allTogether(true);
+```
+<a name="setMagicNumber"></a>
+## setMagicNumber(x)
+Set the magic number.
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| x | <code>[NumberLike](#NumberLike)</code> | The magic number. |
+
+<a name="NumberLike"></a>
+## NumberLike : <code>number</code> &#124; <code>string</code>
+A number, or a string containing a number.
+
+**Kind**: global typedef  
+## END MARKDOWN
+
+An nec aliquid ocurreret, eos everti feugiat in, congue posidonium vis no. Ne cum doming probatus, mel choro iudico ubique in, sed ei odio errem. Eu dico stet splendide sea, exerci adolescens sed ne, cum epicuri conceptam et. Sea veri minim mandamus ne, aeterno offendit elaboraret eum te.
+


### PR DESCRIPTION
Adding functinality for having Markdown files concatenated to the begining/end of the generated documentation. 

This becomes handy for repos where one has a 'static' intro and description and just want to update the documentation part of the README.md, for example.

Cheers